### PR TITLE
Refactor normalization, use pd alias, update tests

### DIFF
--- a/pywikipathways/find_pathways_by_xref.py
+++ b/pywikipathways/find_pathways_by_xref.py
@@ -1,4 +1,5 @@
 import requests
+import pandas as pd
 
 def find_pathways_by_xref(identifier, system_code):
     """Find Pathways By Xref
@@ -65,7 +66,7 @@ def find_pathways_by_xref(identifier, system_code):
             return None
             
         # Convert to DataFrame and return
-        return pandas.DataFrame(filtered_pathways).drop_duplicates(ignore_index=True)
+        return pd.DataFrame(filtered_pathways).drop_duplicates(ignore_index=True)
         
     except requests.exceptions.RequestException as e:
         print(f"Error fetching data: {e}")

--- a/pywikipathways/get_ontology_terms.py
+++ b/pywikipathways/get_ontology_terms.py
@@ -1,6 +1,16 @@
 import requests
 import pandas as pd
 
+
+def _normalize_exploded_column(df, column_name, prefix):
+    exploded_df = df.explode(column_name).reset_index(drop=True)
+    normalized = pd.json_normalize(
+        exploded_df[column_name].apply(lambda value: value if isinstance(value, dict) else {})
+    )
+    if not normalized.empty:
+        normalized.columns = [f"{prefix}_{col}" for col in normalized.columns]
+    return pd.concat([exploded_df.drop(column_name, axis=1), normalized], axis=1)
+
 # ----------------------------------------------------------------------
 # Get Ontology Terms by Pathway
 def get_ontology_terms(pathway=None):
@@ -9,13 +19,7 @@ def get_ontology_terms(pathway=None):
     pathways_data = res['pathways']
     res_df = pd.DataFrame(pathways_data)
     if 'terms' in res_df.columns:
-        # Explode lists to separate rows first, then normalize
-        res_df_exploded = res_df.explode('terms')
-        terms_normalized = pd.json_normalize(res_df_exploded['terms'])
-        terms_normalized.columns = ['terms_' + col for col in terms_normalized.columns]    
-        # Combine back
-        res_df = pd.concat([res_df_exploded.drop('terms', axis=1).reset_index(drop=True), 
-                            terms_normalized.reset_index(drop=True)], axis=1)
+        res_df = _normalize_exploded_column(res_df, 'terms', 'terms')
     
     if pathway is not None:
         res_df = res_df[res_df["id"] == pathway]
@@ -42,13 +46,7 @@ def get_pathways_by_ontology_term(term=None):
     pathways_data = res['terms']
     res_df = pd.DataFrame(pathways_data)
     if 'pathways' in res_df.columns:
-        # Explode lists to separate rows first, then normalize
-        res_df_exploded = res_df.explode('pathways')
-        pathways_normalized = pd.json_normalize(res_df_exploded['pathways'])
-        pathways_normalized.columns = ['pathways_' + col for col in pathways_normalized.columns]    
-        # Combine back
-        res_df = pd.concat([res_df_exploded.drop('pathways', axis=1).reset_index(drop=True), 
-                            pathways_normalized.reset_index(drop=True)], axis=1)    
+        res_df = _normalize_exploded_column(res_df, 'pathways', 'pathways')
     
     if term is not None:
         res_df = res_df[res_df["id"] == term]
@@ -69,13 +67,7 @@ def get_pathways_by_parent_ontology_term(term=None):
     pathways_data = res['pathways']
     res_df = pd.DataFrame(pathways_data)
     if 'terms' in res_df.columns:
-        # Explode lists to separate rows first, then normalize
-        res_df_exploded = res_df.explode('terms')
-        terms_normalized = pd.json_normalize(res_df_exploded['terms'])
-        terms_normalized.columns = ['terms_' + col for col in terms_normalized.columns]    
-        # Combine back
-        res_df = pd.concat([res_df_exploded.drop('terms', axis=1).reset_index(drop=True), 
-                            terms_normalized.reset_index(drop=True)], axis=1)
+        res_df = _normalize_exploded_column(res_df, 'terms', 'terms')
     
     if term is not None:
         res_df = res_df[res_df["terms_parent"] == term]

--- a/tests/test_get_counts.py
+++ b/tests/test_get_counts.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 from pywikipathways.get_counts import get_counts
 
 
@@ -27,7 +28,7 @@ def test_get_counts_return_type():
     result = get_counts()
     
     # Should return either None (network error) or pandas DataFrame
-    assert result is None or str(type(result)) == "<class 'pandas.core.frame.DataFrame'>"
+    assert result is None or isinstance(result, pd.DataFrame)
 
 
 def test_get_counts_no_parameters():


### PR DESCRIPTION
Introduce a shared _normalize_exploded_column helper in get_ontology_terms.py to consolidate repeated explode + json_normalize logic across ontology-related functions. Use pandas alias (import pandas as pd) in find_pathways_by_xref.py and fix a DataFrame construction call to use pd.DataFrame. Update tests/test_get_counts.py to import pandas as pd and replace a fragile type-string check with isinstance(result, pd.DataFrame); also normalize file newline. These changes reduce duplication and make DataFrame checks more robust without changing external behavior.